### PR TITLE
Verbose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.svelte

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,12 +129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
-name = "owo-colors"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,7 +207,6 @@ name = "svg2svelte"
 version = "0.2.0"
 dependencies = [
  "clap",
- "owo-colors",
  "regex",
  "sedregex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ repository = "https://github.com/derektata/svg2svelte-rs"
 
 [dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
-owo-colors = "3.4.0"
 regex = "1.6.0"
 sedregex = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svg2svelte"
 description = "Easily turn an SVG file into a Svelte component, Rewritten in Rust."
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 author = "Derek Tata <derekjtata@gmail.com>"
 license = "AGPL-3.0"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ ARGS:
 OPTIONS:
     -h, --help          Print help information
     -t, --typescript    Create a Typescript component
+    -v, --verbose       Print the generated component to stdout
     -V, --version       Print version information
 
 EXAMPLES:

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,14 @@ struct Cli {
     /// Create a Typescript component
     #[clap(short, long)]
     typescript: bool,
+
+    /// Print the generated component to stdout
+    #[clap(short, long)]
+    verbose: bool,
 }
 
 fn main() {
     let cli = Cli::parse();
     let svg_file = cli.svg_file.unwrap();
-    process(&svg_file, cli.typescript);
+    process(&svg_file, cli.typescript, cli.verbose);
 }


### PR DESCRIPTION
# Added verbosity flag & updated the output
+ process() now takes in a verbosity flag to show the generated
  component, so the utility doesn't flood stdout unless you want it to.
+ Added formatting to describe errors, and where they happen